### PR TITLE
Checking file's basename

### DIFF
--- a/lib/filetype.rb
+++ b/lib/filetype.rb
@@ -1,7 +1,7 @@
 module Filetype
   module_function
 
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 
   FTYPES = {
     :actionscript => %w[ as mxml ],
@@ -69,6 +69,7 @@ module Filetype
   #   Filetype.get('Rakefile') #=> :rake
   # @return [Symbol] The language found or nil
   def get(fname)
+    fname = File.basename(fname)
     FTYPES.each do |ftype, rule|
       case rule
       when Array
@@ -89,6 +90,7 @@ module Filetype
   #   Filetype.all('foo.h') #=> [:c, :cpp, :objc]
   # @return [Array] The list of languages found
   def all(fname)
+    fname = File.basename(fname)
     FTYPES.select do |ftype, rule|
       ftype if rule.is_a?(Array) && rule.include?(ext(fname))
     end.keys


### PR DESCRIPTION
Checking the file's basename in order to prevent unexpected behavior by regexes anchoring to front of string