### PR TITLE
Add docker file format

### DIFF
--- a/lib/filetype.rb
+++ b/lib/filetype.rb
@@ -16,6 +16,7 @@ module Filetype
     :csharp       => %w[ cs ],
     :css          => %w[ css ],
     :diff         => %w[ diff patch ],
+    :docker       => /\A[Dd]ockerfile(?:\.\w+)?\z/,
     :elisp        => %w[ el ],
     :erb          => %w[ rhtml erb ],
     :erlang       => %w[ erl hrl ],

--- a/lib/filetype.rb
+++ b/lib/filetype.rb
@@ -1,7 +1,7 @@
 module Filetype
   module_function
 
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 
   FTYPES = {
     :actionscript => %w[ as mxml ],

--- a/lib/filetype.rb
+++ b/lib/filetype.rb
@@ -1,7 +1,7 @@
 module Filetype
   module_function
 
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 
   FTYPES = {
     :actionscript => %w[ as mxml ],

--- a/test/filetype_test.rb
+++ b/test/filetype_test.rb
@@ -36,6 +36,8 @@ class FileTypeTest < TestCase
     assert_equal :cpp, Filetype.get('foo.hxx')
     assert_equal :csharp, Filetype.get('foo.cs')
     assert_equal :css, Filetype.get('foo.css')
+    assert_equal :docker, Filetype.get('Dockerfile')
+    assert_equal :docker, Filetype.get('Dockerfile.build')
     assert_equal :elisp, Filetype.get('foo.el')
     assert_equal :erb, Filetype.get('foo.rhtml')
     assert_equal :erb, Filetype.get('foo.erb')


### PR DESCRIPTION
This PR adds the Docker file format. It recreates the functionality in https://github.com/leejarvis/filetype/pull/6, however without the behavior changing functionality that that PR also introduces (which will be introduced in a newer version). 